### PR TITLE
build(automation): deploy to github pages on main branch update

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,49 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+
+      - name: Install dependencies
+        uses: bahmutov/npm-install@v1
+
+      - name: Build project
+        run: npm run build
+
+      - name: Upload production-ready build files
+        uses: actions/upload-artifact@v4
+        with:
+          name: production-files
+          path: ./dist
+
+  deploy:
+    name: Deploy
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: production-files
+          path: ./dist
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
         uses: bahmutov/npm-install@v1
 
       - name: Build project
-        run: npm run build
+        run: VITE_BASE=/sudoku-project/ npm run build
 
       - name: Upload production-ready build files
         uses: actions/upload-artifact@v4

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,8 +1,10 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
-// https://vite.dev/config/
+const defaultBase = '/LuluDoku/';
+const base = process.env.VITE_BASE || defaultBase;
+
 export default defineConfig({
   plugins: [react()],
-  base: '/LuluDoku/'
-})
+  base: base
+});


### PR DESCRIPTION
Changes:

- Set base path as parameter
  - dennifportilla.com/LuluDoku as default path
  - Can be overriden by including VITE_BASE={mybasepath} before `npm run build`. See deploy.yml 
- Deploy to github pages, dist branch is `gh-pages`